### PR TITLE
Pass strings through to JNI layer over UTF-8 byte arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Add something like the following to your `pom.xml` or equivalent file:
 <dependency>
 ```
 
-## From Build
+### From Build
 
 The default install directory is `/opt/hse`[^1]. This can be overridden by
 configuring the build with either `-Dprefix=$prefix` or `--prefix=$prefix`.

--- a/src/main/java/com/micron/hse/Hse.java
+++ b/src/main/java/com/micron/hse/Hse.java
@@ -36,11 +36,12 @@ public final class Hse {
     }
 
     /**
-     * {@code config} defaults to {@code null}.
+     * Refer to {@code #init(Path, String...)}.
+     *
+     * <p>{@code config} defaults to {@code null}.</p>
      *
      * @param params List of parameters in key=value format.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #init(Path, String...)
      */
     public static void init(final String... params) throws HseException {
         init(null, params);

--- a/src/main/java/com/micron/hse/Kvdb.java
+++ b/src/main/java/com/micron/hse/Kvdb.java
@@ -110,7 +110,6 @@ public final class Kvdb extends NativeObject implements AutoCloseable {
      * <p>{@code flags} defaults to {@code null}.</p>
      *
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #compact(EnumSet)
      */
     public void compact() throws HseException {
         compact(null);
@@ -262,10 +261,11 @@ public final class Kvdb extends NativeObject implements AutoCloseable {
     }
 
     /**
-     * {@code flags} defaults to {@code null}.
+     * Refer to {@code #sync(EnumSet)}.
+     *
+     * <p>{@code flags} defaults to {@code null}.</p>
      *
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #sync(EnumSet)
      */
     public void sync() throws HseException {
         sync(null);

--- a/src/main/java/com/micron/hse/Kvs.java
+++ b/src/main/java/com/micron/hse/Kvs.java
@@ -6,7 +6,6 @@
 package com.micron.hse;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
 import java.util.Optional;
 
@@ -31,9 +30,13 @@ public final class Kvs extends NativeObject implements AutoCloseable {
     private native void close(long kvsHandle) throws HseException;
     private native void delete(long kvsHandle, byte[] key, int keyLen, int flags,
         long txnHandle) throws HseException;
+    private native void delete(long kvsHandle, String key, int flags, long txnHandle)
+            throws HseException;
     private native void delete(long kvsHandle, ByteBuffer key, int keyLen, int keyPos,
         int flags, long txnHandle) throws HseException;
     private native byte[] get(long kvsHandle, byte[] key, int keyLen, int flags, long txnHandle)
+            throws HseException;
+    private native byte[] get(long kvsHandle, String key, int flags, long txnHandle)
             throws HseException;
     private native byte[] get(long kvsHandle, ByteBuffer key, int keyLen, int keyPos, int flags,
         long txnHandle) throws HseException;
@@ -41,6 +44,10 @@ public final class Kvs extends NativeObject implements AutoCloseable {
         int valueBufSz, int flags, long txnHandle) throws HseException;
     private native int get(long kvsHandle, byte[] key, int keyLen, ByteBuffer valueBuf,
         int valueBufSz, int valueBufPos, int flags, long txnHandle) throws HseException;
+    private native int get(long kvsHandle, String key, byte[] valueBuf, int valueBufSz, int flags,
+        long txnHandle) throws HseException;
+    private native int get(long kvsHandle, String key, ByteBuffer valueBuf, int valueBufSz,
+        int valueBufPos, int flags, long txnHandle) throws HseException;
     private native int get(long kvsHandle, ByteBuffer key, int keyLen, int keyPos,
         byte[] valueBuf, int valueBufSz, int flags, long txnHandle) throws HseException;
     private native int get(long kvsHandle, ByteBuffer key, int keyLen,
@@ -50,17 +57,29 @@ public final class Kvs extends NativeObject implements AutoCloseable {
     private native String getParam(long kvdbHandle, String param) throws HseException;
     private native void prefixDelete(long kvsHandle, byte[] pfx, int pfxLen, int flags,
         long txnHandle) throws HseException;
+    private native void prefixDelete(long kvsHandle, String pfx, int flags, long txnHandle)
+            throws HseException;
     private native void prefixDelete(long kvsHandle, ByteBuffer pfx, int pfxLen, int pfxPos,
         int flags, long txnHandle) throws HseException;
     private native void put(long kvsHandle, byte[] key, int keyLen, byte[] value, int valueLen,
         int flags, long txnHandle) throws HseException;
+    private native void put(long kvsHandle, byte[] key, int keyLen, String value, int flags,
+        long txnHandle) throws HseException;
     private native void put(long kvsHandle, byte[] key, int keyLen, ByteBuffer value, int valueLen,
         int valuePos, int flags, long txnHandle) throws HseException;
+    private native void put(long kvsHandle, String key, byte[] value, int valueLen, int flags,
+        long txnHandle) throws HseException;
+    private native void put(long kvsHandle, String key, String value, int flags, long txnHandle)
+            throws HseException;
+    private native void put(long kvsHandle, String key, ByteBuffer value, int valueLen,
+        int valuePos, int flags, long txnHandle) throws HseException;
+    private native void put(long kvsHandle, ByteBuffer key, int keyLen, int keyPos, byte[] value,
+        int valueLen, int flags, long txnHandle) throws HseException;
+    private native void put(long kvsHandle, ByteBuffer key, int keyLen, int keyPos, String value,
+        int flags, long txnHandle) throws HseException;
     private native void put(long kvsHandle, ByteBuffer key, int keyLen, int keyPos,
         ByteBuffer value, int valueLen, int valuePos, int flags, long txnHandle)
             throws HseException;
-    private native void put(long kvsHandle, ByteBuffer key, int keyLen, int keyPos, byte[] value,
-        int valueLen, int flags, long txnHandle) throws HseException;
 
     /**
      * Create a KVS within the referenced KVDB.
@@ -121,7 +140,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      *
      * @return Cursor.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #cursor(byte[], EnumSet, KvdbTransaction)
      */
     public KvsCursor cursor() throws HseException {
         return cursor((byte[]) null, null, null);
@@ -135,7 +153,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param filter Iteration limited to keys matching this prefix filter.
      * @return Cursor.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #cursor(byte[], EnumSet, KvdbTransaction)
      */
     public KvsCursor cursor(final byte[] filter) throws HseException {
         return cursor(filter, null, null);
@@ -149,7 +166,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param filter Iteration limited to keys matching this prefix filter.
      * @return Cursor.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #cursor(String, EnumSet, KvdbTransaction)
      */
     public KvsCursor cursor(final String filter) throws HseException {
         return cursor(filter, null, null);
@@ -164,7 +180,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @return Cursor.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #cursor(ByteBuffer, EnumSet, KvdbTransaction)
      */
     public KvsCursor cursor(final ByteBuffer filter) throws HseException {
         return cursor(filter, null, null);
@@ -178,7 +193,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param flags Flags for operation specialization.
      * @return Cursor.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #cursor(byte[], EnumSet, KvdbTransaction)
      */
     public KvsCursor cursor(final EnumSet<CreateFlags> flags) throws HseException {
         return cursor((byte[]) null, flags, null);
@@ -192,7 +206,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param txn Transaction context.
      * @return Cursor.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #cursor(byte[], EnumSet, KvdbTransaction)
      */
     public KvsCursor cursor(final KvdbTransaction txn) throws HseException {
         return cursor((byte[]) null, null, txn);
@@ -207,7 +220,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param flags Flags for operation specialization.
      * @return Cursor.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #cursor(byte[], EnumSet, KvdbTransaction)
      */
     public KvsCursor cursor(final byte[] filter, final EnumSet<CreateFlags> flags)
             throws HseException {
@@ -223,7 +235,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param flags Flags for operation specialization.
      * @return Cursor.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #cursor(String, EnumSet, KvdbTransaction)
      */
     public KvsCursor cursor(final String filter, final EnumSet<CreateFlags> flags)
             throws HseException {
@@ -240,7 +251,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @return Cursor.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #cursor(ByteBuffer, EnumSet, KvdbTransaction)
      */
     public KvsCursor cursor(final ByteBuffer filter, final EnumSet<CreateFlags> flags)
             throws HseException {
@@ -256,7 +266,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param txn Transaction context.
      * @return Cursor.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #cursor(byte[], EnumSet, KvdbTransaction)
      */
     public KvsCursor cursor(final byte[] filter, final KvdbTransaction txn) throws HseException {
         return cursor(filter, null, txn);
@@ -271,7 +280,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param txn Transaction context.
      * @return Cursor.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #cursor(String, EnumSet, KvdbTransaction)
      */
     public KvsCursor cursor(final String filter, final KvdbTransaction txn) throws HseException {
         return cursor(filter, null, txn);
@@ -287,7 +295,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @return Cursor.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #cursor(ByteBuffer, EnumSet, KvdbTransaction)
      */
     public KvsCursor cursor(final ByteBuffer filter, final KvdbTransaction txn)
             throws HseException {
@@ -303,7 +310,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param txn Transaction context.
      * @return Cursor.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #cursor(byte[], EnumSet, KvdbTransaction)
      */
     public KvsCursor cursor(final EnumSet<CreateFlags> flags, final KvdbTransaction txn)
             throws HseException {
@@ -390,14 +396,13 @@ public final class Kvs extends NativeObject implements AutoCloseable {
     /**
      * Refer to {@link #cursor(byte[], EnumSet, KvdbTransaction)}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param filter Iteration limited to keys matching this prefix filter.
      * @param flags Flags for operation specialization.
      * @param txn Transaction context.
      * @return Cursor.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #cursor(byte[], EnumSet, KvdbTransaction)
      */
     public KvsCursor cursor(final String filter, final EnumSet<CreateFlags> flags,
             final KvdbTransaction txn) throws HseException {
@@ -433,7 +438,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      *
      * @param key Key to delete.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #delete(byte[], KvdbTransaction)
      */
     public void delete(final byte[] key) throws HseException {
         delete(key, null);
@@ -446,12 +450,9 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      *
      * @param key Key to delete.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #delete(String, KvdbTransaction)
      */
     public void delete(final String key) throws HseException {
-        final byte[] keyData = key == null ? null : key.getBytes(StandardCharsets.UTF_8);
-
-        delete(keyData, null);
+        delete(key, null);
     }
 
     /**
@@ -462,7 +463,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param key Key to delete.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #delete(ByteBuffer, KvdbTransaction)
      */
     public void delete(final ByteBuffer key) throws HseException {
         delete(key, null);
@@ -491,17 +491,16 @@ public final class Kvs extends NativeObject implements AutoCloseable {
     /**
      * Refer to {@link #delete(byte[], KvdbTransaction)}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param key Transaction context.
      * @param txn Key to delete.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #delete(byte[], KvdbTransaction)
      */
     public void delete(final String key, final KvdbTransaction txn) throws HseException {
-        final byte[] keyData = key == null ? null : key.getBytes(StandardCharsets.UTF_8);
+        final long txnHandle = txn == null ? 0 : txn.handle;
 
-        delete(keyData, txn);
+        delete(this.handle, key, 0, txnHandle);
     }
 
     /**
@@ -518,7 +517,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param txn Transaction context.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #delete(byte[], KvdbTransaction)
      */
     public void delete(final ByteBuffer key, final KvdbTransaction txn) throws HseException {
         int keyLen = 0;
@@ -546,7 +544,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @return Buffer into which the value associated with {@code key} will be
      *      copied.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #get(byte[], KvdbTransaction) For full description.
      */
     public Optional<byte[]> get(final byte[] key) throws HseException {
         return get(key, (KvdbTransaction) null);
@@ -561,12 +558,9 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @return Buffer into which the value associated with {@code key} will be
      *      copied.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #get(String, KvdbTransaction)
      */
     public Optional<byte[]> get(final String key) throws HseException {
-        final byte[] keyData = key == null ? null : key.getBytes(StandardCharsets.UTF_8);
-
-        return get(keyData);
+        return get(key, (KvdbTransaction) null);
     }
 
     /**
@@ -579,7 +573,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      *      copied.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #get(ByteBuffer, KvdbTransaction)
      */
     public Optional<byte[]> get(final ByteBuffer key)
             throws HseException {
@@ -594,7 +587,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @return Buffer into which the value associated with {@code key} will be
      *      copied.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #get(byte[], byte[], KvdbTransaction)
      */
     public Optional<byte[]> get(final byte[] key, final KvdbTransaction txn) throws HseException {
         final int keyLen = key == null ? 0 : key.length;
@@ -606,19 +598,18 @@ public final class Kvs extends NativeObject implements AutoCloseable {
     /**
      * Refer to {@link #get(byte[], byte[], KvdbTransaction)}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param key Key to get.
      * @param txn Transaction context.
      * @return Buffer into which the value associated with {@code key} will be
      *      copied.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #get(byte[], KvdbTransaction)
      */
     public Optional<byte[]> get(final String key, final KvdbTransaction txn) throws HseException {
-        final byte[] keyData = key == null ? null : key.getBytes(StandardCharsets.UTF_8);
+        final long txnHandle = txn == null ? 0 : txn.handle;
 
-        return get(keyData, txn);
+        return Optional.ofNullable(get(this.handle, key, 0, txnHandle));
     }
 
     /**
@@ -637,7 +628,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      *      copied.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #get(byte[], KvdbTransaction)
      */
     public Optional<byte[]> get(final ByteBuffer key, final KvdbTransaction txn)
             throws HseException {
@@ -670,7 +660,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      *      will be copied.
      * @return Actual length of the value if {@code key} was found.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #get(byte[], byte[], KvdbTransaction)
      */
     public Optional<Integer> get(final byte[] key, final byte[] valueBuf) throws HseException {
         return get(key, valueBuf, null);
@@ -686,7 +675,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      *      will be copied.
      * @return Actual length of the value if {@code key} was found.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #get(String, byte[], KvdbTransaction)
      */
     public Optional<Integer> get(final String key, final byte[] valueBuf) throws HseException {
         return get(key, valueBuf, null);
@@ -702,7 +690,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      *      will be copied.
      * @return Actual length of the value if {@code key} was found.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #get(ByteBuffer, byte[], KvdbTransaction)
      */
     public Optional<Integer> get(final ByteBuffer key, final byte[] valueBuf) throws HseException {
         return get(key, valueBuf, null);
@@ -720,7 +707,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @return Actual length of the value if {@code key} was found.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #get(byte[], ByteBuffer, KvdbTransaction)
      */
     public Optional<Integer> get(final byte[] key, final ByteBuffer valueBuf) throws HseException {
         return get(key, valueBuf, null);
@@ -738,7 +724,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @return Actual length of the value if {@code key} was found.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #get(String, ByteBuffer, KvdbTransaction)
      */
     public Optional<Integer> get(final String key, final ByteBuffer valueBuf) throws HseException {
         return get(key, valueBuf, null);
@@ -756,7 +741,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @return Actual length of the value if {@code key} was found.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #get(ByteBuffer, ByteBuffer, KvdbTransaction)
      */
     public Optional<Integer> get(final ByteBuffer key, final ByteBuffer valueBuf)
             throws HseException {
@@ -792,7 +776,7 @@ public final class Kvs extends NativeObject implements AutoCloseable {
     /**
      * Refer to {@link #get(byte[], byte[], KvdbTransaction)}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param key Key to get.
      * @param valueBuf Buffer into which the value associated with {@code key}
@@ -800,13 +784,18 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param txn Transaction context.
      * @return Actual length of the value if {@code key} was found.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #get(byte[], byte[], KvdbTransaction)
      */
     public Optional<Integer> get(final String key, final byte[] valueBuf, final KvdbTransaction txn)
             throws HseException {
-        final byte[] keyData = key == null ? null : key.getBytes(StandardCharsets.UTF_8);
+        final int valueBufSz = valueBuf == null ? 0 : valueBuf.length;
+        final long txnHandle = txn == null ? 0 : txn.handle;
 
-        return get(keyData, valueBuf, txn);
+        final int packedValueLen = get(this.handle, key, valueBuf, valueBufSz, 0,
+            txnHandle);
+        final boolean found = (packedValueLen & 0b1) == 1;
+        final int valueLen = packedValueLen >> 1;
+
+        return found ? Optional.of(valueLen) : Optional.empty();
     }
 
     /**
@@ -826,7 +815,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @return Actual length of the value if {@code key} was found.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #get(byte[], byte[], KvdbTransaction)
      */
     public Optional<Integer> get(final ByteBuffer key, final byte[] valueBuf,
             final KvdbTransaction txn) throws HseException {
@@ -874,7 +862,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @return Actual length of the value if {@code key} was found.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #get(byte[], byte[], KvdbTransaction)
      */
 
     public Optional<Integer> get(final byte[] key, final ByteBuffer valueBuf,
@@ -912,7 +899,7 @@ public final class Kvs extends NativeObject implements AutoCloseable {
     /**
      * Refer to {@link #get(byte[], byte[], KvdbTransaction)}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param key Key to get.
      * @param valueBuf Buffer into which the value associated with {@code key}
@@ -922,13 +909,35 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @return Actual length of the value if {@code key} was found.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #get(byte[], byte[], KvdbTransaction)
      */
     public Optional<Integer> get(final String key, final ByteBuffer valueBuf,
             final KvdbTransaction txn) throws HseException {
-        final byte[] keyData = key == null ? null : key.getBytes(StandardCharsets.UTF_8);
+        int valueBufSz = 0;
+        int valueBufPos = 0;
+        if (valueBuf != null) {
+            assert valueBuf.isDirect();
 
-        return get(keyData, valueBuf, txn);
+            valueBufSz = valueBuf.remaining();
+            valueBufPos = valueBuf.position();
+        }
+
+        final long txnHandle = txn == null ? 0 : txn.handle;
+
+        final int packedValueLen = get(this.handle, key, valueBuf, valueBufSz, valueBufPos, 0,
+            txnHandle);
+        final boolean found = (packedValueLen & 0b1) == 1;
+
+        if (!found) {
+            return Optional.empty();
+        }
+
+        final int valueLen = packedValueLen >> 1;
+
+        if (valueBuf != null) {
+            valueBuf.limit(Math.min(valueBuf.limit(), valueLen + valueBufPos));
+        }
+
+        return Optional.of(valueLen);
     }
 
     /**
@@ -949,7 +958,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @return Actual length of the value if {@code key} was found.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #get(byte[], byte[], KvdbTransaction)
      */
     public Optional<Integer> get(final ByteBuffer key, final ByteBuffer valueBuf,
             final KvdbTransaction txn) throws HseException {
@@ -1036,7 +1044,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      *
      * @param pfx Prefix of keys to delete.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #prefixDelete(String, KvdbTransaction)
      */
     public void prefixDelete(final String pfx) throws HseException {
         prefixDelete(pfx, null);
@@ -1050,7 +1057,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param pfx Prefix of keys to delete.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #prefixDelete(ByteBuffer, KvdbTransaction)
      */
     public void prefixDelete(final ByteBuffer pfx) throws HseException {
         prefixDelete(pfx, null);
@@ -1095,17 +1101,16 @@ public final class Kvs extends NativeObject implements AutoCloseable {
     /**
      * Refer to {@link #prefixDelete(byte[], KvdbTransaction)}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param pfx Prefix of keys to delete.
      * @param txn Transaction context.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #prefixDelete(byte[], KvdbTransaction)
      */
     public void prefixDelete(final String pfx, final KvdbTransaction txn) throws HseException {
-        final byte[] pfxData = pfx == null ? null : pfx.getBytes(StandardCharsets.UTF_8);
+        final long txnHandle = txn == null ? 0 : txn.handle;
 
-        prefixDelete(pfxData, txn);
+        prefixDelete(this.handle, pfx, 0, txnHandle);
     }
 
     /**
@@ -1122,7 +1127,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param txn Transaction context.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #prefixDelete(byte[], KvdbTransaction)
      */
     public void prefixDelete(final ByteBuffer pfx, final KvdbTransaction txn) throws HseException {
         int pfxLen = 0;
@@ -1149,7 +1153,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param key Key to put into the KVS.
      * @param value Value associated with {@code key}.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(byte[], byte[], EnumSet, KvdbTransaction)
      */
     public void put(final byte[] key, final byte[] value) throws HseException {
         put(key, value, null, null);
@@ -1163,7 +1166,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param key Key to put into the KVS.
      * @param value Value associated with {@code key}.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(byte[], String, EnumSet, KvdbTransaction)
      */
     public void put(final byte[] key, final String value) throws HseException {
         put(key, value, null, null);
@@ -1178,7 +1180,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param value Value associated with {@code key}.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(byte[], ByteBuffer, EnumSet, KvdbTransaction)
      */
     public void put(final byte[] key, final ByteBuffer value) throws HseException {
         put(key, value, null, null);
@@ -1192,7 +1193,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param key Key to put into the KVS.
      * @param value Value associated with {@code key}.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(String, byte[], EnumSet, KvdbTransaction)
      */
     public void put(final String key, final byte[] value) throws HseException {
         put(key, value, null, null);
@@ -1206,7 +1206,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param key Key to put into the KVS.
      * @param value Value associated with {@code key}.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(String, String, EnumSet, KvdbTransaction)
      */
     public void put(final String key, final String value) throws HseException {
         put(key, value, null, null);
@@ -1221,7 +1220,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param value Value associated with {@code key}.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(String, ByteBuffer, EnumSet, KvdbTransaction)
      */
     public void put(final String key, final ByteBuffer value) throws HseException {
         put(key, value, null, null);
@@ -1236,7 +1234,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param value Value associated with {@code key}.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(ByteBuffer, byte[], EnumSet, KvdbTransaction)
      */
     public void put(final ByteBuffer key, final byte[] value) throws HseException {
         put(key, value, null, null);
@@ -1251,7 +1248,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param value Value associated with {@code key}.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(ByteBuffer, String, EnumSet, KvdbTransaction)
      */
     public void put(final ByteBuffer key, final String value) throws HseException {
         put(key, value, null, null);
@@ -1266,7 +1262,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param value Value associated with {@code key}.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(ByteBuffer, ByteBuffer, EnumSet, KvdbTransaction)
      */
     public void put(final ByteBuffer key, final ByteBuffer value) throws HseException {
         put(key, value, null, null);
@@ -1281,7 +1276,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param value Value associated with {@code key}.
      * @param flags Flags for operation specialization.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(byte[], byte[], EnumSet, KvdbTransaction)
      */
     public void put(final byte[] key, final byte[] value, final EnumSet<PutFlags> flags)
             throws HseException {
@@ -1297,7 +1291,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param value Value associated with {@code key}.
      * @param flags Flags for operation specialization.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(byte[], String, EnumSet, KvdbTransaction)
      */
     public void put(final byte[] key, final String value, final EnumSet<PutFlags> flags)
             throws HseException {
@@ -1314,7 +1307,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param flags Flags for operation specialization.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(byte[], ByteBuffer, EnumSet, KvdbTransaction)
      */
     public void put(final byte[] key, final ByteBuffer value, final EnumSet<PutFlags> flags)
             throws HseException {
@@ -1330,7 +1322,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param value Value associated with {@code key}.
      * @param flags Flags for operation specialization.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(String, byte[], EnumSet, KvdbTransaction)
      */
     public void put(final String key, final byte[] value, final EnumSet<PutFlags> flags)
             throws HseException {
@@ -1346,7 +1337,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param value Value associated with {@code key}.
      * @param flags Flags for operation specialization.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(String, String, EnumSet, KvdbTransaction)
      */
     public void put(final String key, final String value, final EnumSet<PutFlags> flags)
             throws HseException {
@@ -1363,7 +1353,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param flags Flags for operation specialization.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(String, ByteBuffer, EnumSet, KvdbTransaction)
      */
     public void put(final String key, final ByteBuffer value, final EnumSet<PutFlags> flags)
             throws HseException {
@@ -1380,7 +1369,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param flags Flags for operation specialization.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(ByteBuffer, byte[], EnumSet, KvdbTransaction)
      */
     public void put(final ByteBuffer key, final byte[] value, final EnumSet<PutFlags> flags)
             throws HseException {
@@ -1397,7 +1385,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param flags Flags for operation specialization.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(ByteBuffer, String, EnumSet, KvdbTransaction)
      */
     public void put(final ByteBuffer key, final String value, final EnumSet<PutFlags> flags)
             throws HseException {
@@ -1414,7 +1401,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param flags Flags for operation specialization.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(ByteBuffer, ByteBuffer, EnumSet, KvdbTransaction)
      */
     public void put(final ByteBuffer key, final ByteBuffer value,
             final EnumSet<PutFlags> flags) throws HseException {
@@ -1430,7 +1416,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param value Value associated with {@code key}.
      * @param txn Transaction context.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(byte[], byte[], EnumSet, KvdbTransaction)
      */
     public void put(final byte[] key, final byte[] value, final KvdbTransaction txn)
             throws HseException {
@@ -1446,7 +1431,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param value Value associated with {@code key}.
      * @param txn Transaction context.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(byte[], String, EnumSet, KvdbTransaction)
      */
     public void put(final byte[] key, final String value, final KvdbTransaction txn)
             throws HseException {
@@ -1463,7 +1447,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param txn Transaction context.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(byte[], ByteBuffer, EnumSet, KvdbTransaction)
      */
     public void put(final byte[] key, final ByteBuffer value, final KvdbTransaction txn)
             throws HseException {
@@ -1480,7 +1463,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param txn Transaction context.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(String, byte[], EnumSet, KvdbTransaction)
      */
     public void put(final String key, final byte[] value, final KvdbTransaction txn)
             throws HseException {
@@ -1496,7 +1478,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param value Value associated with {@code key}.
      * @param txn Transaction context.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(String, String, EnumSet, KvdbTransaction)
      */
     public void put(final String key, final String value, final KvdbTransaction txn)
             throws HseException {
@@ -1513,7 +1494,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param txn Transaction context.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(String, ByteBuffer, EnumSet, KvdbTransaction)
      */
     public void put(final String key, final ByteBuffer value, final KvdbTransaction txn)
             throws HseException {
@@ -1530,7 +1510,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param txn Transaction context.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(ByteBuffer, byte[], EnumSet, KvdbTransaction)
      */
     public void put(final ByteBuffer key, final byte[] value, final KvdbTransaction txn)
             throws HseException {
@@ -1547,7 +1526,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param txn Transaction context.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(ByteBuffer, String, EnumSet, KvdbTransaction)
      */
     public void put(final ByteBuffer key, final String value, final KvdbTransaction txn)
             throws HseException {
@@ -1564,7 +1542,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param txn Transaction context.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(ByteBuffer, ByteBuffer, EnumSet, KvdbTransaction)
      */
     public void put(final ByteBuffer key, final ByteBuffer value, final KvdbTransaction txn)
             throws HseException {
@@ -1625,20 +1602,24 @@ public final class Kvs extends NativeObject implements AutoCloseable {
     /**
      * Refer to {@link #put(byte[], byte[], EnumSet, KvdbTransaction)}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param key Key to put into the KVS.
      * @param value Value associated with {@code key}.
      * @param flags Flags for operation specialization.
      * @param txn Transaction context.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(byte[], byte[], EnumSet, KvdbTransaction)
      */
     public void put(final byte[] key, final String value, final EnumSet<PutFlags> flags,
             final KvdbTransaction txn) throws HseException {
-        final byte[] valueData = value == null ? null : value.getBytes(StandardCharsets.UTF_8);
+        final int keyLen = key == null ? 0 : key.length;
 
-        put(key, valueData, flags, txn);
+        final int flagsValue = flags == null ? 0 : flags.stream()
+            .mapToInt(flag -> 1 << flag.ordinal())
+            .sum();
+        final long txnHandle = txn == null ? 0 : txn.handle;
+
+        put(this.handle, key, keyLen, value, flagsValue, txnHandle);
     }
 
     /**
@@ -1657,7 +1638,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param txn Transaction context.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(byte[], byte[], EnumSet, KvdbTransaction)
      */
     public void put(final byte[] key, final ByteBuffer value, final EnumSet<PutFlags> flags,
             final KvdbTransaction txn) throws HseException {
@@ -1670,6 +1650,8 @@ public final class Kvs extends NativeObject implements AutoCloseable {
 
             valueLen = value.remaining();
             valuePos = value.position();
+
+            value.position(value.limit());
         }
 
         final int flagsValue = flags == null ? 0 : flags.stream()
@@ -1684,59 +1666,77 @@ public final class Kvs extends NativeObject implements AutoCloseable {
     /**
      * Refer to {@link #put(byte[], byte[], EnumSet, KvdbTransaction)}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param key Key to put into the KVS.
      * @param value Value associated with {@code key}.
      * @param flags Flags for operation specialization.
      * @param txn Transaction context.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(byte[], byte[], EnumSet, KvdbTransaction)
      */
     public void put(final String key, final byte[] value, final EnumSet<PutFlags> flags,
             final KvdbTransaction txn) throws HseException {
-        final byte[] keyData = key == null ? null : key.getBytes(StandardCharsets.UTF_8);
+        final int valueLen = value == null ? 0 : value.length;
 
-        put(keyData, value, flags, txn);
+        final int flagsValue = flags == null ? 0 : flags.stream()
+            .mapToInt(flag -> 1 << flag.ordinal())
+            .sum();
+        final long txnHandle = txn == null ? 0 : txn.handle;
+
+        put(this.handle, key, value, valueLen, flagsValue, txnHandle);
     }
 
     /**
      * Refer to {@link #put(byte[], byte[], EnumSet, KvdbTransaction)}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param key Key to put into the KVS.
      * @param value Value associated with {@code key}.
      * @param flags Flags for operation specialization.
      * @param txn Transaction context.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(byte[], byte[], EnumSet, KvdbTransaction)
      */
     public void put(final String key, final String value, final EnumSet<PutFlags> flags,
             final KvdbTransaction txn) throws HseException {
-        final byte[] keyData = key == null ? null : key.getBytes(StandardCharsets.UTF_8);
-        final byte[] valueData = value == null ? null : value.getBytes(StandardCharsets.UTF_8);
+        final int flagsValue = flags == null ? 0 : flags.stream()
+            .mapToInt(flag -> 1 << flag.ordinal())
+            .sum();
+        final long txnHandle = txn == null ? 0 : txn.handle;
 
-        put(keyData, valueData, flags, txn);
+        put(this.handle, key, value, flagsValue, txnHandle);
     }
 
     /**
      * Refer to {@link #put(byte[], byte[], EnumSet, KvdbTransaction)}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param key Key to put into the KVS.
      * @param value Value associated with {@code key}.
      * @param flags Flags for operation specialization.
      * @param txn Transaction context.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(byte[], ByteBuffer, EnumSet, KvdbTransaction)
      */
     public void put(final String key, final ByteBuffer value, final EnumSet<PutFlags> flags,
             final KvdbTransaction txn) throws HseException {
-        final byte[] keyData = key == null ? null : key.getBytes(StandardCharsets.UTF_8);
+        int valueLen = 0;
+        int valuePos = 0;
+        if (value != null) {
+            assert value.isDirect();
 
-        put(keyData, value, flags, txn);
+            valueLen = value.remaining();
+            valuePos = value.position();
+
+            value.position(value.limit());
+        }
+
+        final int flagsValue = flags == null ? 0 : flags.stream()
+            .mapToInt(flag -> 1 << flag.ordinal())
+            .sum();
+        final long txnHandle = txn == null ? 0 : txn.handle;
+
+        put(this.handle, key, value, valueLen, valuePos, flagsValue, txnHandle);
     }
 
     /**
@@ -1755,7 +1755,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param txn Transaction context.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(byte[], byte[], EnumSet, KvdbTransaction)
      */
     public void put(final ByteBuffer key, final byte[] value,
             final EnumSet<PutFlags> flags, final KvdbTransaction txn) throws HseException {
@@ -1782,7 +1781,7 @@ public final class Kvs extends NativeObject implements AutoCloseable {
     /**
      * Refer to {@link #put(byte[], byte[], EnumSet, KvdbTransaction)}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * <p>Any {@link ByteBuffer} arguments must be direct.</p>
      *
@@ -1797,13 +1796,26 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param txn Transaction context.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(ByteBuffer, byte[], EnumSet, KvdbTransaction)
      */
     public void put(final ByteBuffer key, final String value,
             final EnumSet<PutFlags> flags, final KvdbTransaction txn) throws HseException {
-        final byte[] valueData = value == null ? null : value.getBytes(StandardCharsets.UTF_8);
+        int keyLen = 0;
+        int keyPos = 0;
+        if (key != null) {
+            assert key.isDirect();
 
-        put(key, valueData, flags, txn);
+            keyLen = key.remaining();
+            keyPos = key.position();
+
+            key.position(key.limit());
+        }
+
+        final int flagsValue = flags == null ? 0 : flags.stream()
+            .mapToInt(flag -> 1 << flag.ordinal())
+            .sum();
+        final long txnHandle = txn == null ? 0 : txn.handle;
+
+        put(this.handle, key, keyLen, keyPos, value, flagsValue, txnHandle);
     }
 
     /**
@@ -1822,7 +1834,6 @@ public final class Kvs extends NativeObject implements AutoCloseable {
      * @param txn Transaction context.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #put(byte[], byte[], EnumSet, KvdbTransaction)
      */
     public void put(final ByteBuffer key, final ByteBuffer value,
             final EnumSet<PutFlags> flags, final KvdbTransaction txn) throws HseException {

--- a/src/main/java/com/micron/hse/KvsCursor.java
+++ b/src/main/java/com/micron/hse/KvsCursor.java
@@ -7,7 +7,6 @@ package com.micron.hse;
 
 import java.io.EOFException;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.AbstractMap.SimpleImmutableEntry;
@@ -30,19 +29,12 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
 
     KvsCursor(final Kvs kvs, final String filter, EnumSet<CreateFlags> flags,
             final KvdbTransaction txn) throws HseException {
-        byte[] filterData = null;
-        int filterLen = 0;
-        if (filter != null) {
-            filterData = filter.getBytes(StandardCharsets.UTF_8);
-            filterLen = filterData.length;
-        }
-
         final long txnHandle = txn == null ? 0 : txn.handle;
         final int flagsValue = flags == null ? 0 : flags.stream()
             .mapToInt(flag -> 1 << flag.ordinal())
             .sum();
 
-        this.handle = create(kvs.handle, filterData, filterLen, flagsValue, txnHandle);
+        this.handle = create(kvs.handle, filter, flagsValue, txnHandle);
     }
 
     KvsCursor(final Kvs kvs, final ByteBuffer filter, EnumSet<CreateFlags> flags,
@@ -68,6 +60,8 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
 
     private static native long create(long kvsHandle, byte[] filter, int filterLen, int flags,
         long txnHandle) throws HseException;
+    private static native long create(long kvsHandle, String filter, int flags, long txnHandle)
+            throws HseException;
     private static native long create(long kvsHandle, ByteBuffer filter, int filterLen,
         int filterPos, int flags, long txnHandle) throws HseException;
     private native void destroy(long cursorHandle) throws HseException;
@@ -86,12 +80,17 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
         int flags) throws HseException;
     private native byte[] seek(long cursorHandle, byte[] key, int keyLen, int flags)
             throws HseException;
+    private native byte[] seek(long cursorHandle, String key, int flags) throws HseException;
     private native byte[] seek(long cursorHandle, ByteBuffer key, int keyLen, int keyPos, int flags)
             throws HseException;
     private native int seek(long cursorHandle, byte[] key, int keyLen, byte[] foundBuf,
         int foundBufSz, int flags) throws HseException;
     private native int seek(long cursorHandle, byte[] key, int keyLen, ByteBuffer foundBuf,
         int foundBufSz, int foundBufPos, int flags) throws HseException;
+    private native int seek(long cursorHandle, String key, byte[] foundBuf, int foundBufSz,
+        int flags) throws HseException;
+    private native int seek(long cursorHandle, String key, ByteBuffer foundBuf, int foundBufSz,
+        int foundBufPos, int flags) throws HseException;
     private native int seek(long cursorHandle, ByteBuffer key, int keyLen, int keyPos,
         byte[] foundBuf, int foundBufSz, int flags) throws HseException;
     private native int seek(long cursorHandle, ByteBuffer key, int keyLen, int keyPos,
@@ -100,9 +99,19 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
     private native byte[] seekRange(long cursorHandle, byte[] filterMin, int filterMinLen,
         byte[] filterMax, int filterMaxLen, int flags) throws HseException;
     private native byte[] seekRange(long cursorHandle, byte[] filterMin, int filterMinLen,
+        String filterMax, int flags) throws HseException;
+    private native byte[] seekRange(long cursorHandle, byte[] filterMin, int filterMinLen,
         ByteBuffer filterMax, int filterMaxLen, int filterMaxPos, int flags) throws HseException;
+    private native byte[] seekRange(long cursorHandle, String filterMin, byte[] filterMax,
+        int filterMaxLen, int flags) throws HseException;
+    private native byte[] seekRange(long cursorHandle, String filterMin, String filterMax,
+        int flags) throws HseException;
+    private native byte[] seekRange(long cursorHandle, String filterMin, ByteBuffer filterMax,
+        int filterMaxLen, int filterMaxPos, int flags) throws HseException;
     private native byte[] seekRange(long cursorHandle, ByteBuffer filterMin, int filterMinLen,
         int filterMinPos, byte[] filterMax, int filterMaxLen, int flags) throws HseException;
+    private native byte[] seekRange(long cursorHandle, ByteBuffer filterMin, int filterMinLen,
+        int filterMinPos, String filterMax, int flags) throws HseException;
     private native byte[] seekRange(long cursorHandle, ByteBuffer filterMin, int filterMinLen,
         int filterMinPos, ByteBuffer filterMax, int filterMaxLen, int filterMaxPos, int flags)
             throws HseException;
@@ -113,17 +122,43 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
         byte[] filterMax, int filterMaxLen, ByteBuffer foundBuf, int foundBufSz, int foundBufPos,
         int flags) throws HseException;
     private native int seekRange(long cursorHandle, byte[] filterMin, int filterMinLen,
+        String filterMax, byte[] foundBuf, int foundBufSz, int flags) throws HseException;
+    private native int seekRange(long cursorHandle, byte[] filterMin, int filterMinLen,
+        String filterMax, ByteBuffer foundBuf, int foundBufSz, int foundBufPos, int flags)
+            throws HseException;
+    private native int seekRange(long cursorHandle, byte[] filterMin, int filterMinLen,
         ByteBuffer filterMax, int filterMaxLen, int filterMaxPos, byte[] foundBuf, int foundBufSz,
         int flags) throws HseException;
     private native int seekRange(long cursorHandle, byte[] filterMin, int filterMinLen,
         ByteBuffer filterMax, int filterMaxLen, int filterMaxPos, ByteBuffer foundBuf,
         int foundBufSz, int foundBufPos, int flags) throws HseException;
+    private native int seekRange(long cursorHandle, String filterMin, byte[] filterMax,
+        int filterMaxLen, byte[] foundBuf, int foundBufSz, int flags) throws HseException;
+    private native int seekRange(long cursorHandle, String filterMin, byte[] filterMax,
+        int filterMaxLen, ByteBuffer foundBuf, int foundBufSz, int foundBufPos, int flags)
+            throws HseException;
+    private native int seekRange(long cursorHandle, String filterMin, String filterMax,
+        byte[] foundBuf, int foundBufSz, int flags) throws HseException;
+    private native int seekRange(long cursorHandle, String filterMin, String filterMax,
+        ByteBuffer foundBuf, int foundBufSz, int foundBufPos, int flags) throws HseException;
+    private native int seekRange(long cursorHandle, String filterMin, ByteBuffer filterMax,
+        int filterMaxLen, int filterMaxPos, byte[] foundBuf, int foundBufSz, int flags)
+            throws HseException;
+    private native int seekRange(long cursorHandle, String filterMin, ByteBuffer filterMax,
+        int filterMaxLen, int filterMaxPos, ByteBuffer foundBuf, int foundBufSz, int foundBufPos,
+        int flags) throws HseException;
     private native int seekRange(long cursorHandle, ByteBuffer filterMin, int filterMinLen,
         int filterMinPos, byte[] filterMax, int filterMaxLen, byte[] foundBuf, int foundBufSz,
         int flags) throws HseException;
     private native int seekRange(long cursorHandle, ByteBuffer filterMin, int filterMinLen,
         int filterMinPos, byte[] filterMax, int filterMaxLen, ByteBuffer foundBuf, int foundBufSz,
         int foundBufPos, int flags) throws HseException;
+    private native int seekRange(long cursorHandle, ByteBuffer filterMin, int filterMinLen,
+        int filterMinPos, String filterMax, byte[] foundBuf, int foundBufSz, int flags)
+            throws HseException;
+    private native int seekRange(long cursorHandle, ByteBuffer filterMin, int filterMinLen,
+        int filterMinPos, String filterMax, ByteBuffer foundBuf, int foundBufSz, int foundBufPos,
+        int flags) throws HseException;
     private native int seekRange(long cursorHandle, ByteBuffer filterMin, int filterMinLen,
         int filterMinPos, ByteBuffer filterMax, int filterMaxLen, int filterMaxPos, byte[] foundBuf,
         int foundBufSz, int flags) throws HseException;
@@ -138,7 +173,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Key-value pair.
      * @throws EOFException Cursor has no more elements to read.
      * @throws HseException Underlying C function returned a non-zero value
-     * @see #read(byte[], byte[])
      */
     public SimpleImmutableEntry<byte[], byte[]> read()
             throws EOFException, HseException {
@@ -186,7 +220,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Key and value lengths.
      * @throws EOFException Cursor has no more elements to read.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #read(byte[], byte[])
      */
     public SimpleImmutableEntry<Integer, Integer> read(final byte[] keyBuf,
             final ByteBuffer valueBuf) throws EOFException, HseException {
@@ -228,12 +261,11 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Key and value lengths.
      * @throws EOFException Cursor has no more elements to read.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #read(byte[], byte[])
      */
     public SimpleImmutableEntry<Integer, Integer> read(final ByteBuffer keyBuf,
             final byte[] valueBuf) throws EOFException, HseException {
-        int keyBufPos = 0;
         int keyBufSz = 0;
+        int keyBufPos = 0;
         if (keyBuf != null) {
             assert keyBuf.isDirect();
 
@@ -273,7 +305,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws EOFException Cursor has no more elements to read.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #read(byte[], byte[])
      */
     public SimpleImmutableEntry<Integer, Integer> read(final ByteBuffer keyBuf,
             final ByteBuffer valueBuf) throws EOFException, HseException {
@@ -282,17 +313,17 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
         if (keyBuf != null) {
             assert keyBuf.isDirect();
 
-            keyBufPos = keyBuf.position();
             keyBufSz = keyBuf.remaining();
+            keyBufPos = keyBuf.position();
         }
 
-        int valueBufPos = 0;
         int valueBufSz = 0;
+        int valueBufPos = 0;
         if (valueBuf != null) {
             assert valueBuf.isDirect();
 
-            valueBufPos = valueBuf.position();
             valueBufSz = valueBuf.remaining();
+            valueBufPos = valueBuf.position();
         }
 
         final SimpleImmutableEntry<Integer, Integer> entry = read(this.handle,
@@ -315,7 +346,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @param key Key to find.
      * @return Next key in sequence.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seek(byte[], byte[])
      */
     public Optional<byte[]> seek(final byte[] key) throws HseException {
         final int keyLen = key == null ? 0 : key.length;
@@ -326,17 +356,14 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
     /**
      * Refer to {@link #seek(byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param key Key to find.
      * @return Next key in sequence.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seek(byte[])
      */
     public Optional<byte[]> seek(final String key) throws HseException {
-        final byte[] keyData = key == null ? null : key.getBytes(StandardCharsets.UTF_8);
-
-        return seek(keyData);
+        return Optional.ofNullable(seek(this.handle, key, 0));
     }
 
     /**
@@ -353,7 +380,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Next key in sequence.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seek(byte[])
      */
     public Optional<byte[]> seek(final ByteBuffer key)
             throws HseException {
@@ -386,16 +412,15 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      */
     public Optional<Integer> seek(final byte[] key, final byte[] foundBuf) throws HseException {
         final int keyLen = key == null ? 0 : key.length;
-        final int foundBufSz = foundBuf == null ? 0 : key.length;
+        final int foundBufSz = foundBuf == null ? 0 : foundBuf.length;
 
-        final int packedFoundLen = seek(this.handle, key, keyLen, foundBuf, foundBufSz, 0);
-        final boolean found = (packedFoundLen & 0b1) == 1;
+        final int foundLen = seek(this.handle, key, keyLen, foundBuf, foundBufSz, 0);
 
-        if (!found) {
+        if (foundLen == 0) {
             return Optional.empty();
         }
 
-        return Optional.of(packedFoundLen >> 1);
+        return Optional.of(foundLen);
     }
 
     /**
@@ -415,7 +440,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Length of the found key.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seek(byte[], byte[])
      */
     public Optional<Integer> seek(final byte[] key, final ByteBuffer foundBuf)
             throws HseException {
@@ -430,15 +454,11 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
             foundBufPos = foundBuf.position();
         }
 
-        final int packedFoundLen = seek(this.handle, key, keyLen, foundBuf, foundBufSz, foundBufPos,
-            0);
-        final boolean found = (packedFoundLen & 0b1) == 1;
+        final int foundLen = seek(this.handle, key, keyLen, foundBuf, foundBufSz, foundBufPos, 0);
 
-        if (!found) {
+        if (foundLen == 0) {
             return Optional.empty();
         }
-
-        final int foundLen = packedFoundLen >> 1;
 
         if (foundBuf != null) {
             foundBuf.limit(Math.min(foundBuf.limit(), foundBufPos + foundLen));
@@ -450,24 +470,29 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
     /**
      * Refer to {@link #seek(byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param key Key to find.
      * @param foundBuf Next key in sequence.
      * @return Length of the found key.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seek(byte[], byte[])
      */
     public Optional<Integer> seek(final String key, final byte[] foundBuf) throws HseException {
-        final byte[] keyData = key == null ? null : key.getBytes(StandardCharsets.UTF_8);
+        final int foundBufSz = foundBuf == null ? 0 : foundBuf.length;
 
-        return seek(keyData, foundBuf);
+        final int foundLen = seek(this.handle, key, foundBuf, foundBufSz, 0);
+
+        if (foundLen == 0) {
+            return Optional.empty();
+        }
+
+        return Optional.of(foundLen);
     }
 
     /**
      * Refer to {@link #seek(byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param key Key to find.
      * @param foundBuf Next key in sequence. {@link ByteBuffer#limit(int)} will
@@ -476,13 +501,29 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Length of the found key.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seek(byte[], ByteBuffer)
      */
     public Optional<Integer> seek(final String key, final ByteBuffer foundBuf)
             throws HseException {
-        final byte[] keyData = key == null ? null : key.getBytes(StandardCharsets.UTF_8);
+        int foundBufSz = 0;
+        int foundBufPos = 0;
+        if (foundBuf != null) {
+            assert foundBuf.isDirect();
 
-        return seek(keyData, foundBuf);
+            foundBufSz = foundBuf.remaining();
+            foundBufPos = foundBuf.position();
+        }
+
+        final int foundLen = seek(this.handle, key, foundBuf, foundBufSz, foundBufPos, 0);
+
+        if (foundLen == 0) {
+            return Optional.empty();
+        }
+
+        if (foundBuf != null) {
+            foundBuf.limit(Math.min(foundBuf.limit(), foundBufPos + foundLen));
+        }
+
+        return Optional.of(foundLen);
     }
 
     /**
@@ -500,7 +541,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Length of the found key.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seek(byte[], byte[])
      */
     public Optional<Integer> seek(final ByteBuffer key, final byte[] foundBuf)
             throws HseException {
@@ -517,21 +557,19 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
 
         final int foundBufSz = foundBuf == null ? 0 : foundBuf.length;
 
-        final int packedFoundLen = seek(this.handle, key, keyLen, keyPos, foundBuf, foundBufSz,
-            0);
-        final boolean found = (packedFoundLen & 0b1) == 1;
+        final int foundLen = seek(this.handle, key, keyLen, keyPos, foundBuf, foundBufSz, 0);
 
-        if (!found) {
+        if (foundLen == 0) {
             return Optional.empty();
         }
 
-        return Optional.of(packedFoundLen >> 1);
+        return Optional.of(foundLen);
     }
 
     /**
      * Refer to {@link #seek(byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * <p>Any {@link ByteBuffer} arguments must be direct.</p>
      *
@@ -547,7 +585,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Length of the found key.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seek(byte[], byte[])
      */
     public Optional<Integer> seek(final ByteBuffer key, final ByteBuffer foundBuf)
             throws HseException {
@@ -558,6 +595,8 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
 
             keyLen = key.remaining();
             keyPos = key.position();
+
+            key.position(key.limit());
         }
 
         int foundBufSz = 0;
@@ -569,15 +608,12 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
             foundBufPos = foundBuf.position();
         }
 
-        final int packedFoundLen = seek(this.handle, key, keyLen, keyPos, foundBuf, foundBufSz,
+        final int foundLen = seek(this.handle, key, keyLen, keyPos, foundBuf, foundBufSz,
             foundBufPos, 0);
-        final boolean found = (packedFoundLen & 0b1) == 1;
 
-        if (!found) {
+        if (foundLen == 0) {
             return Optional.empty();
         }
-
-        final int foundLen = packedFoundLen >> 1;
 
         if (foundBuf != null) {
             foundBuf.limit(Math.min(foundBuf.limit(), foundBufPos + foundLen));
@@ -593,7 +629,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @param filterMax Filter maximum.
      * @return Next key in sequence.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[], byte[])
      */
     public Optional<byte[]> seekRange(final byte[] filterMin, final byte[] filterMax)
             throws HseException {
@@ -607,20 +642,18 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
     /**
      * Refer to {@link #seekRange(byte[], byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param filterMin Filter minimum.
      * @param filterMax Filter maximum.
      * @return Next key in sequence.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[])
      */
     public Optional<byte[]> seekRange(final byte[] filterMin, final String filterMax)
             throws HseException {
-        final byte[] filterMaxData = filterMax == null
-            ? null : filterMax.getBytes(StandardCharsets.UTF_8);
+        final int filterMinLen = filterMin == null ? 0 : filterMin.length;
 
-        return seekRange(filterMin, filterMaxData);
+        return Optional.ofNullable(seekRange(this.handle, filterMin, filterMinLen, filterMax, 0));
     }
 
     /**
@@ -638,7 +671,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Next key in sequence.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[])
      */
     public Optional<byte[]> seekRange(final byte[] filterMin, final ByteBuffer filterMax)
             throws HseException {
@@ -662,61 +694,61 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
     /**
      * Refer to {@link #seekRange(byte[], byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param filterMin Filter minimum.
      * @param filterMax Filter maximum.
      * @return Next key in sequence.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[])
      */
     public Optional<byte[]> seekRange(final String filterMin, final byte[] filterMax)
             throws HseException {
-        final byte[] filterMinData = filterMin == null
-            ? null : filterMin.getBytes(StandardCharsets.UTF_8);
+        final int filterMaxLen = filterMax == null ? 0 : filterMax.length;
 
-        return seekRange(filterMinData, filterMax);
+        return Optional.ofNullable(seekRange(this.handle, filterMin, filterMax, filterMaxLen, 0));
     }
 
     /**
      * Refer to {@link #seekRange(byte[], byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param filterMin Filter minimum.
      * @param filterMax Filter maximum.
      * @return Next key in sequence.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[])
      */
     public Optional<byte[]> seekRange(final String filterMin, final String filterMax)
             throws HseException {
-        final byte[] filterMinData = filterMin == null
-            ? null : filterMin.getBytes(StandardCharsets.UTF_8);
-        final byte[] filterMaxData = filterMax == null
-            ? null : filterMax.getBytes(StandardCharsets.UTF_8);
-
-        return seekRange(filterMinData, filterMaxData);
+        return Optional.ofNullable(seekRange(this.handle, filterMin, filterMax, 0));
     }
 
     /**
      * Refer to {@link #seekRange(byte[], byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param filterMin Filter minimum.
      * @param filterMax Filter maximum.
      * @return Next key in sequence.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[])
      */
     public Optional<byte[]> seekRange(final String filterMin, final ByteBuffer filterMax)
             throws HseException {
-        final byte[] filterMinData = filterMin == null
-            ? null : filterMin.getBytes(StandardCharsets.UTF_8);
+        int filterMaxLen = 0;
+        int filterMaxPos = 0;
+        if (filterMax != null) {
+            assert filterMax.isDirect();
 
-        return seekRange(filterMinData, filterMax);
+            filterMaxLen = filterMax.remaining();
+            filterMaxPos = filterMax.position();
+
+            filterMax.position(filterMax.limit());
+        }
+
+        return Optional.ofNullable(seekRange(this.handle, filterMin, filterMax, filterMaxLen,
+            filterMaxPos, 0));
     }
 
     /**
@@ -734,7 +766,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Next key in sequence.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[])
      */
     public Optional<byte[]> seekRange(final ByteBuffer filterMin, final byte[] filterMax)
             throws HseException {
@@ -743,8 +774,10 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
         if (filterMin != null) {
             assert filterMin.isDirect();
 
-            filterMinLen = filterMin.limit();
+            filterMinLen = filterMin.remaining();
             filterMinPos = filterMin.position();
+
+            filterMin.position(filterMin.limit());
         }
 
         final int filterMaxLen = filterMax == null ? 0 : filterMax.length;
@@ -756,21 +789,29 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
     /**
      * Refer to {@link #seekRange(byte[], byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param filterMin Filter minimum.
      * @param filterMax Filter maximum.
      * @return Next key in sequence.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[])
      */
     public Optional<byte[]> seekRange(final ByteBuffer filterMin, final String filterMax)
             throws HseException {
-        final byte[] filterMaxData = filterMax == null
-            ? null : filterMax.getBytes(StandardCharsets.UTF_8);
+        int filterMinLen = 0;
+        int filterMinPos = 0;
+        if (filterMin != null) {
+            assert filterMin.isDirect();
 
-        return seekRange(filterMin, filterMaxData);
+            filterMinLen = filterMin.remaining();
+            filterMinPos = filterMin.position();
+
+            filterMin.position(filterMin.limit());
+        }
+
+        return Optional.ofNullable(seekRange(this.handle, filterMin, filterMinLen, filterMinPos,
+            filterMax, 0));
     }
 
     /**
@@ -788,7 +829,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Next key in sequence.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[])
      */
     public Optional<byte[]> seekRange(final ByteBuffer filterMin, final ByteBuffer filterMax)
             throws HseException {
@@ -845,15 +885,14 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
         final int filterMaxLen = filterMax == null ? 0 : filterMax.length;
         final int foundBufSz = foundBuf == null ? 0 : foundBuf.length;
 
-        final int packedFoundLen = seekRange(this.handle, filterMin, filterMinLen, filterMax,
+        final int foundLen = seekRange(this.handle, filterMin, filterMinLen, filterMax,
             filterMaxLen, foundBuf, foundBufSz, 0);
-        final boolean found = (packedFoundLen & 0b1) == 1;
 
-        if (!found) {
+        if (foundLen == 0) {
             return Optional.empty();
         }
 
-        return Optional.of(packedFoundLen >> 1);
+        return Optional.of(foundLen);
     }
 
     /**
@@ -874,7 +913,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Length of the found key.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[], byte[])
      */
     public Optional<Integer> seekRange(final byte[] filterMin, final byte[] filterMax,
             final ByteBuffer foundBuf) throws HseException {
@@ -890,15 +928,12 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
             foundBufPos = foundBuf.position();
         }
 
-        final int packedFoundLen = seekRange(this.handle, filterMin, filterMinLen, filterMax,
+        final int foundLen = seekRange(this.handle, filterMin, filterMinLen, filterMax,
             filterMaxLen, foundBuf, foundBufSz, foundBufPos, 0);
-        final boolean found = (packedFoundLen & 0b1) == 1;
 
-        if (!found) {
+        if (foundLen == 0) {
             return Optional.empty();
         }
-
-        final int foundLen = packedFoundLen >> 1;
 
         if (foundBuf != null) {
             foundBuf.limit(Math.min(foundBuf.limit(), foundBufPos + foundLen));
@@ -910,27 +945,33 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
     /**
      * Refer to {@link #seekRange(byte[], byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param filterMin Filter minimum.
      * @param filterMax Filter maximum.
      * @param foundBuf Next key in sequence.
      * @return Length of the found key.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[], byte[])
      */
     public Optional<Integer> seekRange(final byte[] filterMin, final String filterMax,
             final byte[] foundBuf) throws HseException {
-        final byte[] filterMaxData = filterMax == null
-            ? null : filterMax.getBytes(StandardCharsets.UTF_8);
+        final int filterMinLen = filterMin == null ? 0 : filterMin.length;
+        final int foundBufSz = foundBuf == null ? 0 : foundBuf.length;
 
-        return seekRange(filterMin, filterMaxData, foundBuf);
+        final int foundLen = seekRange(this.handle, filterMin, filterMinLen, filterMax, foundBuf,
+            foundBufSz, 0);
+
+        if (foundLen == 0) {
+            return Optional.empty();
+        }
+
+        return Optional.of(foundLen);
     }
 
     /**
      * Refer to {@link #seekRange(byte[], byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param filterMin Filter minimum.
      * @param filterMax Filter maximum.
@@ -940,14 +981,32 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Length of the found key.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[], byte[])
      */
     public Optional<Integer> seekRange(final byte[] filterMin, final String filterMax,
             final ByteBuffer foundBuf) throws HseException {
-        final byte[] filterMaxData = filterMax == null
-            ? null : filterMax.getBytes(StandardCharsets.UTF_8);
+        final int filterMinLen = filterMin == null ? 0 : filterMin.length;
 
-        return seekRange(filterMin, filterMaxData, foundBuf);
+        int foundBufSz = 0;
+        int foundBufPos = 0;
+        if (foundBuf != null) {
+            assert foundBuf.isDirect();
+
+            foundBufSz = foundBuf.remaining();
+            foundBufPos = foundBuf.position();
+        }
+
+        final int foundLen = seekRange(this.handle, filterMin, filterMinLen, filterMax,
+            foundBuf, foundBufSz, foundBufPos, 0);
+
+        if (foundLen == 0) {
+            return Optional.empty();
+        }
+
+        if (foundBuf != null) {
+            foundBuf.limit(Math.min(foundBuf.limit(), foundBufPos + foundLen));
+        }
+
+        return Optional.of(foundLen);
     }
 
     /**
@@ -966,7 +1025,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Length of the found key.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[], byte[])
      */
     public Optional<Integer> seekRange(final byte[] filterMin, final ByteBuffer filterMax,
             final byte[] foundBuf) throws HseException {
@@ -985,15 +1043,14 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
 
         final int foundBufSz = foundBuf == null ? 0 : foundBuf.length;
 
-        final int packedFoundLen = seekRange(this.handle, filterMin, filterMinLen, filterMax,
+        final int foundLen = seekRange(this.handle, filterMin, filterMinLen, filterMax,
             filterMaxLen, filterMaxPos, foundBuf, foundBufSz, 0);
-        final boolean found = (packedFoundLen & 0b1) == 1;
 
-        if (!found) {
+        if (foundLen == 0) {
             return Optional.empty();
         }
 
-        return Optional.of(packedFoundLen >> 1);
+        return Optional.of(foundLen);
     }
 
     /**
@@ -1014,7 +1071,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Length of the found key.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[], byte[])
      */
     public Optional<Integer> seekRange(final byte[] filterMin, final ByteBuffer filterMax,
             final ByteBuffer foundBuf) throws HseException {
@@ -1027,6 +1083,8 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
 
             filterMaxLen = filterMax.remaining();
             filterMaxPos = filterMax.position();
+
+            filterMax.position(filterMax.limit());
         }
 
         int foundBufSz = 0;
@@ -1038,15 +1096,12 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
             foundBufPos = foundBuf.position();
         }
 
-        final int packedFoundLen = seekRange(this.handle, filterMin, filterMinLen, filterMax,
+        final int foundLen = seekRange(this.handle, filterMin, filterMinLen, filterMax,
             filterMaxLen, filterMaxPos, foundBuf, foundBufSz, foundBufPos, 0);
-        final boolean found = (packedFoundLen & 0b1) == 1;
 
-        if (!found) {
+        if (foundLen == 0) {
             return Optional.empty();
         }
-
-        final int foundLen = packedFoundLen >> 1;
 
         if (foundBuf != null) {
             foundBuf.limit(Math.min(foundBuf.limit(), foundBufPos + foundLen));
@@ -1058,27 +1113,33 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
     /**
      * Refer to {@link #seekRange(byte[], byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param filterMin Filter minimum.
      * @param filterMax Filter maximum.
      * @param foundBuf Next key in sequence.
      * @return Length of the found key.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[], byte[])
      */
     public Optional<Integer> seekRange(final String filterMin, final byte[] filterMax,
             final byte[] foundBuf) throws HseException {
-        final byte[] filterMinData = filterMin == null
-            ? null : filterMin.getBytes(StandardCharsets.UTF_8);
+        final int filterMaxLen = filterMax == null ? 0 : filterMax.length;
+        final int foundBufSz = foundBuf == null ? 0 : foundBuf.length;
 
-        return seekRange(filterMinData, filterMax, foundBuf);
+        final int foundLen = seekRange(this.handle, filterMin, filterMax, filterMaxLen,
+            foundBuf, foundBufSz, 0);
+
+        if (foundLen == 0) {
+            return Optional.empty();
+        }
+
+        return Optional.of(foundLen);
     }
 
     /**
      * Refer to {@link #seekRange(byte[], byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param filterMin Filter minimum.
      * @param filterMax Filter maximum.
@@ -1088,42 +1149,62 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Length of the found key.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[], ByteBuffer)
      */
     public Optional<Integer> seekRange(final String filterMin, final byte[] filterMax,
             final ByteBuffer foundBuf) throws HseException {
-        final byte[] filterMinData = filterMin == null
-            ? null : filterMin.getBytes(StandardCharsets.UTF_8);
+        final int filterMaxLen = filterMax == null ? 0 : filterMax.length;
 
-        return seekRange(filterMinData, filterMax, foundBuf);
+        int foundBufSz = 0;
+        int foundBufPos = 0;
+        if (foundBuf != null) {
+            assert foundBuf.isDirect();
+
+            foundBufSz = foundBuf.remaining();
+            foundBufPos = foundBuf.position();
+        }
+
+        final int foundLen = seekRange(this.handle, filterMin, filterMax, filterMaxLen,
+            foundBuf, foundBufSz, foundBufPos, 0);
+
+        if (foundLen == 0) {
+            return Optional.empty();
+        }
+
+        if (foundBuf != null) {
+            foundBuf.limit(Math.min(foundBuf.limit(), foundBufPos + foundLen));
+        }
+
+        return Optional.of(foundLen);
     }
 
     /**
      * Refer to {@link #seekRange(byte[], byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param filterMin Filter minimum.
      * @param filterMax Filter maximum.
      * @param foundBuf Next key in sequence.
      * @return Length of the found key.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[], byte[])
      */
     public Optional<Integer> seekRange(final String filterMin, final String filterMax,
             final byte[] foundBuf) throws HseException {
-        final byte[] filterMinData = filterMin == null
-            ? null : filterMin.getBytes(StandardCharsets.UTF_8);
-        final byte[] filterMaxData = filterMax == null
-            ? null : filterMax.getBytes(StandardCharsets.UTF_8);
+        final int foundBufSz = foundBuf == null ? 0 : foundBuf.length;
 
-        return seekRange(filterMinData, filterMaxData, foundBuf);
+        final int foundLen = seekRange(this.handle, filterMin, filterMax, foundBuf, foundBufSz, 0);
+
+        if (foundLen == 0) {
+            return Optional.empty();
+        }
+
+        return Optional.of(foundLen);
     }
 
     /**
      * Refer to {@link #seekRange(byte[], byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param filterMin Filter minimum.
      * @param filterMax Filter maximum.
@@ -1133,20 +1214,36 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Length of the found key.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[], ByteBuffer)
      */
     public Optional<Integer> seekRange(final String filterMin, final String filterMax,
             final ByteBuffer foundBuf) throws HseException {
-        final byte[] filterMinData = filterMin == null
-            ? null : filterMin.getBytes(StandardCharsets.UTF_8);
+        int foundBufSz = 0;
+        int foundBufPos = 0;
+        if (foundBuf != null) {
+            assert foundBuf.isDirect();
 
-        return seekRange(filterMinData, filterMax, foundBuf);
+            foundBufSz = foundBuf.remaining();
+            foundBufPos = foundBuf.position();
+        }
+
+        final int foundLen = seekRange(this.handle, filterMin, filterMax, foundBuf,
+            foundBufSz, foundBufPos, 0);
+
+        if (foundLen == 0) {
+            return Optional.empty();
+        }
+
+        if (foundBuf != null) {
+            foundBuf.limit(Math.min(foundBuf.limit(), foundBufPos + foundLen));
+        }
+
+        return Optional.of(foundLen);
     }
 
     /**
      * Refer to {@link #seekRange(byte[], byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param filterMin Filter minimum.
      * @param filterMax Filter maximum.
@@ -1154,20 +1251,36 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Length of the found key.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], ByteBuffer, byte[])
      */
     public Optional<Integer> seekRange(final String filterMin, final ByteBuffer filterMax,
             final byte[] foundBuf) throws HseException {
-        final byte[] filterMinData = filterMin == null
-            ? null : filterMin.getBytes(StandardCharsets.UTF_8);
+        int filterMaxLen = 0;
+        int filterMaxPos = 0;
+        if (filterMax != null) {
+            assert filterMax.isDirect();
 
-        return seekRange(filterMinData, filterMax, foundBuf);
+            filterMaxLen = filterMax.remaining();
+            filterMaxPos = filterMax.position();
+
+            filterMax.position(filterMax.limit());
+        }
+
+        final int foundBufSz = foundBuf == null ? 0 : foundBuf.length;
+
+        final int foundLen = seekRange(this.handle, filterMin, filterMax, filterMaxLen,
+            filterMaxPos, foundBuf, foundBufSz, 0);
+
+        if (foundLen == 0) {
+            return Optional.empty();
+        }
+
+        return Optional.of(foundLen);
     }
 
     /**
      * Refer to {@link #seekRange(byte[], byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param filterMin Filter minimum.
      * @param filterMax Filter maximum.
@@ -1177,14 +1290,41 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Length of the found key.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], ByteBuffer, ByteBuffer)
      */
     public Optional<Integer> seekRange(final String filterMin, final ByteBuffer filterMax,
             final ByteBuffer foundBuf) throws HseException {
-        final byte[] filterMinData = filterMin == null
-            ? null : filterMin.getBytes(StandardCharsets.UTF_8);
+        int filterMaxLen = 0;
+        int filterMaxPos = 0;
+        if (filterMax != null) {
+            assert filterMax.isDirect();
 
-        return seekRange(filterMinData, filterMax, foundBuf);
+            filterMaxLen = filterMax.remaining();
+            filterMaxPos = filterMax.position();
+
+            filterMax.position(filterMax.limit());
+        }
+
+        int foundBufSz = 0;
+        int foundBufPos = 0;
+        if (foundBuf != null) {
+            assert foundBuf.isDirect();
+
+            foundBufSz = foundBuf.remaining();
+            foundBufPos = foundBuf.position();
+        }
+
+        final int foundLen = seekRange(this.handle, filterMin, filterMax, filterMaxLen,
+            filterMaxPos, foundBuf, foundBufSz, foundBufPos, 0);
+
+        if (foundLen == 0) {
+            return Optional.empty();
+        }
+
+        if (foundBuf != null) {
+            foundBuf.limit(Math.min(foundBuf.limit(), foundBufPos + foundLen));
+        }
+
+        return Optional.of(foundLen);
     }
 
     /**
@@ -1203,7 +1343,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Length of the found key.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[], byte[])
      */
     public Optional<Integer> seekRange(final ByteBuffer filterMin, final byte[] filterMax,
             final byte[] foundBuf) throws HseException {
@@ -1221,91 +1360,14 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
         final int filterMaxLen = filterMax == null ? 0 : filterMax.length;
         final int foundBufSz = foundBuf == null ? 0 : foundBuf.length;
 
-        final int packedFoundLen = seekRange(this.handle, filterMin, filterMinLen, filterMinPos,
+        final int foundLen = seekRange(this.handle, filterMin, filterMinLen, filterMinPos,
             filterMax, filterMaxLen, foundBuf, foundBufSz, 0);
-        final boolean found = (packedFoundLen & 0b1) == 1;
 
-        if (!found) {
+        if (foundLen == 0) {
             return Optional.empty();
         }
 
-        return Optional.of(packedFoundLen >> 1);
-    }
-
-    /**
-     * Refer to {@link #seekRange(byte[], byte[], byte[])}.
-     *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
-     *
-     * @param filterMin Filter minimum.
-     * @param filterMax Filter maximum.
-     * @param foundBuf Next key in sequence.
-     * @return Length of the found key.
-     * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
-     * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(ByteBuffer, byte[], byte[])
-     */
-    public Optional<Integer> seekRange(final ByteBuffer filterMin, final String filterMax,
-            final byte[] foundBuf) throws HseException {
-        final byte[] filterMaxData = filterMax == null
-            ? null : filterMax.getBytes(StandardCharsets.UTF_8);
-
-        return seekRange(filterMin, filterMaxData, foundBuf);
-    }
-
-    /**
-     * Refer to {@link #seekRange(byte[], byte[], byte[])}.
-     *
-     * <p>Any {@link ByteBuffer} arguments must be direct.</p>
-     *
-     * <p>
-     * Note that the length of any byte buffer given to HSE is
-     * {@link ByteBuffer#limit()} - {@link ByteBuffer#position()}.
-     * </p>
-     *
-     * @param filterMin Filter minimum.
-     * @param filterMax Filter maximum.
-     * @param foundBuf Next key in sequence.
-     * @return Length of the found key.
-     * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
-     * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[], byte[])
-     */
-    public Optional<Integer> seekRange(final ByteBuffer filterMin, final ByteBuffer filterMax,
-            final byte[] foundBuf) throws HseException {
-        int filterMinLen = 0;
-        int filterMinPos = 0;
-        if (filterMin != null) {
-            assert filterMin.isDirect();
-
-            filterMinLen = filterMin.remaining();
-            filterMinPos = filterMin.position();
-
-            filterMax.position(filterMax.limit());
-        }
-
-        int filterMaxLen = 0;
-        int filterMaxPos = 0;
-        if (filterMax != null) {
-            assert filterMax.isDirect();
-
-            filterMaxLen = filterMax.remaining();
-            filterMaxPos = filterMax.position();
-
-            filterMax.position(filterMax.limit());
-        }
-
-        final int foundBufSz = foundBuf == null ? 0 : foundBuf.length;
-
-        final int packedFoundLen = seekRange(this.handle, filterMin, filterMinLen, filterMinPos,
-            filterMax, filterMaxLen, filterMaxPos, foundBuf, foundBufSz, 0);
-        final boolean found = (packedFoundLen & 0b1) == 1;
-
-        if (!found) {
-            return Optional.empty();
-        }
-
-        return Optional.of(packedFoundLen >> 1);
+        return Optional.of(foundLen);
     }
 
     /**
@@ -1326,7 +1388,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Length of the found key.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[], byte[])
      */
     public Optional<Integer> seekRange(final ByteBuffer filterMin, final byte[] filterMax,
             final ByteBuffer foundBuf) throws HseException {
@@ -1352,15 +1413,12 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
             foundBufPos = foundBuf.position();
         }
 
-        final int packedFoundLen = seekRange(this.handle, filterMin, filterMinLen, filterMinPos,
+        final int foundLen = seekRange(this.handle, filterMin, filterMinLen, filterMinPos,
             filterMax, filterMaxLen, foundBuf, foundBufSz, foundBufPos, 0);
-        final boolean found = (packedFoundLen & 0b1) == 1;
 
-        if (!found) {
+        if (foundLen == 0) {
             return Optional.empty();
         }
-
-        final int foundLen = packedFoundLen >> 1;
 
         if (foundBuf != null) {
             foundBuf.limit(Math.min(foundBuf.limit(), foundBufPos + foundLen));
@@ -1372,7 +1430,44 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
     /**
      * Refer to {@link #seekRange(byte[], byte[], byte[])}.
      *
-     * <p>Any {@link String} arguments are converted to UTF-8 byte arrays.</p>
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
+     *
+     * @param filterMin Filter minimum.
+     * @param filterMax Filter maximum.
+     * @param foundBuf Next key in sequence.
+     * @return Length of the found key.
+     * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
+     * @throws HseException Underlying C function returned a non-zero value.
+     */
+    public Optional<Integer> seekRange(final ByteBuffer filterMin, final String filterMax,
+            final byte[] foundBuf) throws HseException {
+        int filterMinLen = 0;
+        int filterMinPos = 0;
+        if (filterMin != null) {
+            assert filterMin.isDirect();
+
+            filterMinLen = filterMin.remaining();
+            filterMinPos = filterMin.position();
+
+            filterMin.position(filterMin.limit());
+        }
+
+        final int foundBufSz = foundBuf == null ? 0 : foundBuf.length;
+
+        final int foundLen = seekRange(this.handle, filterMin, filterMinLen, filterMinPos,
+            filterMax, foundBuf, foundBufSz, 0);
+
+        if (foundLen == 0) {
+            return Optional.empty();
+        }
+
+        return Optional.of(foundLen);
+    }
+
+    /**
+     * Refer to {@link #seekRange(byte[], byte[], byte[])}.
+     *
+     * <p>Any {@link String} arguments are converted to UTF-8 bytes.</p>
      *
      * @param filterMin Filter minimum.
      * @param filterMax Filter maximum.
@@ -1382,14 +1477,94 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Length of the found key.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(ByteBuffer, byte[], ByteBuffer)
      */
     public Optional<Integer> seekRange(final ByteBuffer filterMin, final String filterMax,
             final ByteBuffer foundBuf) throws HseException {
-        final byte[] filterMaxData = filterMax == null
-            ? null : filterMax.getBytes(StandardCharsets.UTF_8);
+        int filterMinLen = 0;
+        int filterMinPos = 0;
+        if (filterMin != null) {
+            assert filterMin.isDirect();
 
-        return seekRange(filterMin, filterMaxData, foundBuf);
+            filterMinLen = filterMin.remaining();
+            filterMinPos = filterMin.position();
+
+            filterMin.position(filterMin.limit());
+        }
+
+        int foundBufSz = 0;
+        int foundBufPos = 0;
+        if (foundBuf != null) {
+            assert foundBuf.isDirect();
+
+            foundBufSz = foundBuf.remaining();
+            foundBufPos = foundBuf.position();
+        }
+
+        final int foundLen = seekRange(this.handle, filterMin, filterMinLen, filterMinPos,
+            filterMax, foundBuf, foundBufSz, foundBufPos, 0);
+
+        if (foundLen == 0) {
+            return Optional.empty();
+        }
+
+        if (foundBuf != null) {
+            foundBuf.limit(Math.min(foundBuf.limit(), foundBufPos + foundLen));
+        }
+
+        return Optional.of(foundLen);
+    }
+
+    /**
+     * Refer to {@link #seekRange(byte[], byte[], byte[])}.
+     *
+     * <p>Any {@link ByteBuffer} arguments must be direct.</p>
+     *
+     * <p>
+     * Note that the length of any byte buffer given to HSE is
+     * {@link ByteBuffer#limit()} - {@link ByteBuffer#position()}.
+     * </p>
+     *
+     * @param filterMin Filter minimum.
+     * @param filterMax Filter maximum.
+     * @param foundBuf Next key in sequence.
+     * @return Length of the found key.
+     * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
+     * @throws HseException Underlying C function returned a non-zero value.
+     */
+    public Optional<Integer> seekRange(final ByteBuffer filterMin, final ByteBuffer filterMax,
+            final byte[] foundBuf) throws HseException {
+        int filterMinLen = 0;
+        int filterMinPos = 0;
+        if (filterMin != null) {
+            assert filterMin.isDirect();
+
+            filterMinLen = filterMin.remaining();
+            filterMinPos = filterMin.position();
+
+            filterMin.position(filterMin.limit());
+        }
+
+        int filterMaxLen = 0;
+        int filterMaxPos = 0;
+        if (filterMax != null) {
+            assert filterMax.isDirect();
+
+            filterMaxLen = filterMax.remaining();
+            filterMaxPos = filterMax.position();
+
+            filterMax.position(filterMax.limit());
+        }
+
+        final int foundBufSz = foundBuf == null ? 0 : foundBuf.length;
+
+        final int foundLen = seekRange(this.handle, filterMin, filterMinLen, filterMinPos,
+            filterMax, filterMaxLen, filterMaxPos, foundBuf, foundBufSz, 0);
+
+        if (foundLen == 0) {
+            return Optional.empty();
+        }
+
+        return Optional.of(foundLen);
     }
 
     /**
@@ -1410,7 +1585,6 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
      * @return Length of the found key.
      * @throws AssertionError All {@link ByteBuffer} parameters must be direct.
      * @throws HseException Underlying C function returned a non-zero value.
-     * @see #seekRange(byte[], byte[], byte[])
      */
     public Optional<Integer> seekRange(final ByteBuffer filterMin, final ByteBuffer filterMax,
             final ByteBuffer foundBuf) throws HseException {
@@ -1445,15 +1619,12 @@ public final class KvsCursor extends NativeObject implements AutoCloseable {
             foundBufPos = foundBuf.position();
         }
 
-        final int packedFoundLen = seekRange(this.handle, filterMin, filterMinLen, filterMinPos,
+        final int foundLen = seekRange(this.handle, filterMin, filterMinLen, filterMinPos,
             filterMax, filterMaxLen, filterMaxPos, foundBuf, foundBufSz, foundBufPos, 0);
-        final boolean found = (packedFoundLen & 0b1) == 1;
 
-        if (!found) {
+        if (foundLen == 0) {
             return Optional.empty();
         }
-
-        final int foundLen = packedFoundLen >> 1;
 
         if (foundBuf != null) {
             foundBuf.limit(Math.min(foundBuf.limit(), foundBufPos + foundLen));

--- a/subprojects/hse.wrap
+++ b/subprojects/hse.wrap
@@ -1,6 +1,7 @@
 [wrap-git]
 url = https://github.com/hse-project/hse.git
 revision = master
+depth = 1
 
 [provide]
 dependency_names = hse-2


### PR DESCRIPTION
I realized that converting the Strings to byte arrays was incurring an
extra copy along the way. A simple microbenchmark seemed to indicate
that we could gain performance increases avoiding String::getBytes() and
calling GetStringUTFChars() within the JNI layer.

Signed-off-by: Tristan Partin <tpartin@micron.com>
