### PR TITLE
Move to Meson 0.62

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -55,13 +55,23 @@ jobs:
         run: |
           git -C "subprojects/$b" checkout ${{ github.head_ref }} || true
 
+      - name: Get Meson on ubuntu-18.04
+        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        run: |
+          sudo apt-get install python3.7
+          sudo python3.7 -m pip install meson
+
+      - name: Get Meson on ubuntu-20.04
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        run: |
+          sudo python3 -m pip install meson
+
       - name: Initialize
         run: |
           sudo apt-get update
           sudo apt-get install build-essential ninja-build pkg-config maven \
             openjdk-8-jdk libbsd-dev libmicrohttpd-dev liburcu-dev \
             libyaml-dev liblz4-dev libcurl4-openssl-dev
-          sudo python3 -m pip install meson
 
       - name: Setup
         run: |
@@ -86,7 +96,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: fedora:${{ matrix.image-tag }}
-      options: --privileged  -v /usr/src:/usr/src -v /lib/modules:/lib/modules
     strategy:
       fail-fast: false
       matrix:
@@ -112,10 +121,11 @@ jobs:
         run: |
           dnf group install -y --with-optional \
             "C Development Tools and Libraries"
-          dnf install -y git ninja-build meson pkg-config maven \
+          dnf install -y git python3-pip ninja-build pkg-config maven \
             java-1.8.0-openjdk-devel libmicrohttpd-devel userspace-rcu-devel \
             libyaml-devel lz4-devel libbsd-devel libcurl-devel libxml2-devel \
             libxslt-devel
+          python3 -m pip install meson
 
       - name: Setup
         run: |
@@ -140,7 +150,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: almalinux:${{ matrix.image-tag }}
-      options: --privileged  -v /usr/src:/usr/src -v /lib/modules:/lib/modules
     strategy:
       fail-fast: false
       matrix:
@@ -164,12 +173,13 @@ jobs:
 
       - name: Initialize
         run: |
-          dnf install -y sudo dnf-plugins-core epel-release
+          dnf install -y dnf-plugins-core epel-release
+          dnf update -y
           dnf config-manager --set-enabled powertools
           dnf group install -y --with-optional "Development Tools"
           dnf install -y git ninja-build pkg-config maven \
             java-1.8.0-openjdk-devel libmicrohttpd-devel userspace-rcu-devel \
-            libyaml-devel lz4-devel libbsd-devel libcurl-devel python36 \
+            libyaml-devel lz4-devel libbsd-devel libcurl-devel python38 \
             libxml2 libxslt
           python3 -m pip install meson
 

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@ project(
         # options :).
         'force_fallback_for=xxhash,lz4,cjson',
     ],
-    meson_version: '>= 0.59.0'
+    meson_version: '>= 0.62.0'
 )
 
 package = 'com.micron.hse'
@@ -27,6 +27,7 @@ hse_java_patch_version = version_components[2]
 jar_filename = 'hse-@0@.jar'.format(meson.project_version())
 
 fs = import('fs')
+javamod = import('java')
 
 cc = meson.get_compiler('c')
 javac = meson.get_compiler('java')
@@ -35,7 +36,7 @@ mvn = find_program('mvn', required: get_option('tests'), disabler: true)
 
 python = find_program('python3', required: get_option('tests'))
 
-jdk_dep = dependency('jdk', version: '>= 1.8.0')
+jni_dep = dependency('jni', version: '>= 1.8.0')
 hse_dep = dependency(
     'hse-2',
     version: '>= 2.2.0',
@@ -100,22 +101,20 @@ if not meson.is_subproject()
         ]
     )
 
-    if mvn.found()
-        run_target(
-            'deploy',
-            command: [
-                'sh',
-                '-c',
-                ' '.join([
-                    mvn.full_path(),
-                    'deploy:deploy-file',
-                    '"-Durl=${HSE_JAVA_DEPLOY_URL:-file://$HOME/.m2/repository}"',
-                    '-Dmaven.test.skip=true',
-                    '-DpomFile=' + meson.project_source_root() / 'pom.xml',
-                    '-Dfile=' + hse_jar.full_path(),
-                ])
-            ],
-            depends: [hse_jar]
-        )
-    endif
+    run_target(
+        'deploy',
+        command: [
+            'sh',
+            '-c',
+            ' '.join([
+                mvn.full_path(),
+                'deploy:deploy-file',
+                '"-Durl=${HSE_JAVA_DEPLOY_URL:-file://$HOME/.m2/repository}"',
+                '-Dmaven.test.skip=true',
+                '-DpomFile=' + meson.project_source_root() / 'pom.xml',
+                '-Dfile=' + hse_jar.full_path(),
+            ])
+        ],
+        depends: [hse_jar]
+    )
 endif

--- a/src/main/c/meson.build
+++ b/src/main/c/meson.build
@@ -10,38 +10,18 @@ c_sources = files(
     'hsejni.c'
 )
 
-java_classes = [
-    'Hse',
-    'Kvdb',
-    'Kvdb_CompactStatus',
-    'KvdbTransaction',
-    'Kvs',
-    'KvsCursor',
-    'MclassInfo',
-    'Version',
-]
-
-native_headers_file_names = []
-
-foreach jc : java_classes
-    native_headers_file_names += '@0@_@1@.h'.format(
-        package.replace('.', '_'),
-        jc.replace('.', '_')
-    )
-endforeach
-
-native_headers = custom_target(
-    'native-headers',
-    input: java_sources,
-    output: native_headers_file_names,
-    command: [
-        javac.cmd_array(),
-        '-d',
-        # Java 1.8.0 won't create the directory for us
-        javac.version().version_compare('> 1.8.0') ? '@PRIVATE_DIR@' : meson.current_build_dir(),
-        '-h',
-        meson.current_build_dir(),
-        java_sources,
+native_headers = javamod.generate_native_headers(
+    java_sources,
+    package: package,
+    classes: [
+        'Hse',
+        'Kvdb',
+        'Kvdb.CompactStatus',
+        'KvdbTransaction',
+        'Kvs',
+        'KvsCursor',
+        'MclassInfo',
+        'Version',
     ]
 )
 
@@ -57,7 +37,7 @@ hsejni = shared_module(
     include_directories: include_directories('.'),
     dependencies: [
         hse_dep,
-        jdk_dep,
+        jni_dep,
     ],
     gnu_symbol_visibility: 'hidden',
     install: true


### PR DESCRIPTION
Meson 0.62 has a good amount of Java improvements when it comes to
Meson.

Namely jdk got renamed to jni and java.generate_native_headers(). Both
of which this commit takes advantage of. Less custom code and using best
practices is always a plus.

Signed-off-by: Tristan Partin <tpartin@micron.com>
