### PR TITLE
Remove default install dir for JAR

### DIFF
--- a/src/main/java/meson.build
+++ b/src/main/java/meson.build
@@ -15,6 +15,5 @@ java_sources = files(
 hse_jar = jar(
     fs.stem(jar_filename),
     java_sources,
-    install: true,
-    install_dir: get_option('datadir') / 'java'
+    install: true
 )


### PR DESCRIPTION
What was previously there is now the default in Meson 0.62.

Signed-off-by: Tristan Partin <tpartin@micron.com>
