### PR TITLE
Use meson setup

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -173,7 +173,7 @@ jobs:
       - name: Setup
         if: ${{ steps.to-skip.outputs.skip == 'false' }}
         run: |
-          meson builddir --buildtype=${{ matrix.buildtype }} $CROSS_ARGS \
+          meson setup builddir --buildtype=${{ matrix.buildtype }} $CROSS_ARGS \
             --werror
 
       - name: Build


### PR DESCRIPTION
Leaving out the setup command is deprecated in Meson master.

Signed-off-by: Tristan Partin <tpartin@micron.com>
