### PR TITLE
Add 'all' test setup

### DIFF
--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -15,6 +15,11 @@ add_test_setup(
 )
 
 add_test_setup(
+    'all',
+    exe_wrapper: wrapper
+)
+
+add_test_setup(
     'ci',
     exe_wrapper: wrapper
 )


### PR DESCRIPTION
Due to a Meson issue, test suites only really work when the same suite name exists in a subproject.

Signed-off-by: Tristan Partin <tpartin@micron.com>
